### PR TITLE
Update to allow option pre/post traffic hooks and canary toggle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea


### PR DESCRIPTION
Update to allow option pre/post traffic hooks.
Update also allows you to set:

```
custom:
    deploymentSettings:
        preprodDeployment: true/false
```

I'd like to discuss in more depth.