### PR TITLE
Hopefully fixes #20 by passing an empty hash if custom does not exist

### DIFF
--- a/serverless-plugin-canary-deployments.js
+++ b/serverless-plugin-canary-deployments.js
@@ -207,7 +207,7 @@ class ServerlessCanaryDeployments {
   }
 
   getDeploymentSettingsFor(serverlessFunction) {
-    const globalSettings = _.cloneDeep(this.service.custom.deploymentSettings);
+    const globalSettings = _.cloneDeep((this.service.custom || {}).deploymentSettings);
     const fnDeploymentSetting = this.service.getFunction(serverlessFunction).deploymentSettings;
     return Object.assign({}, globalSettings, fnDeploymentSetting);
   }


### PR DESCRIPTION
If custom is null (IE: not there) it is initialized as an empty hash
now. As Object.assign ignores null sources this effectively fixes the
issue. I've tested packaging and deploying myself without issue.

How to test:
  1. in the example, comment out the "serverless-plugin-aws-alerts"
plugin (as it also has this issue) and the custom key.
  2. run the example (either deploy or package).
  
On master it throws an error with the posted trace.