### PR TITLE
Switch from Fn::Sub to Fn::Join in CF templates

### DIFF
--- a/fixtures/1.output.json
+++ b/fixtures/1.output.json
@@ -286,7 +286,20 @@
           "IntegrationHttpMethod": "POST",
           "Type": "AWS_PROXY",
           "Uri": {
-            "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloLambdaFunctionAliasLive}/invocations"
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Ref": "HelloLambdaFunctionAliasLive"
+                },
+                "/invocations"
+              ]
+            ]
           }
         },
         "MethodResponses": []

--- a/fixtures/2.output.without-hooks.json
+++ b/fixtures/2.output.without-hooks.json
@@ -190,7 +190,20 @@
           "IntegrationHttpMethod": "POST",
           "Type": "AWS_PROXY",
           "Uri": {
-            "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloLambdaFunctionAliasLive}/invocations"
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Ref": "HelloLambdaFunctionAliasLive"
+                },
+                "/invocations"
+              ]
+            ]
           }
         },
         "MethodResponses": []

--- a/fixtures/3.output.with-existing-codedeploy-role.json
+++ b/fixtures/3.output.with-existing-codedeploy-role.json
@@ -286,7 +286,20 @@
           "IntegrationHttpMethod": "POST",
           "Type": "AWS_PROXY",
           "Uri": {
-            "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloLambdaFunctionAliasLive}/invocations"
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Ref": "HelloLambdaFunctionAliasLive"
+                },
+                "/invocations"
+              ]
+            ]
           }
         },
         "MethodResponses": []

--- a/lib/CfTemplateGenerators/ApiGateway.js
+++ b/lib/CfTemplateGenerators/ApiGateway.js
@@ -2,11 +2,13 @@ const _ = require('lodash/fp');
 
 function buildUriForAlias(functionAlias) {
   const aliasArn = [
-    'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${',
-    functionAlias,
-    '}/invocations'
-  ].join('');
-  return { 'Fn::Sub': aliasArn };
+    'arn:aws:apigateway:',
+    { 'Ref': 'AWS::Region' },
+    ':lambda:path/2015-03-31/functions/',
+    { 'Ref': functionAlias },
+    '/invocations'
+  ];
+  return { 'Fn::Join': [ '', aliasArn ] };
 }
 
 function replaceMethodUriWithAlias(apiGatewayMethod, functionAlias) {

--- a/lib/CfTemplateGenerators/ApiGateway.test.js
+++ b/lib/CfTemplateGenerators/ApiGateway.test.js
@@ -33,11 +33,13 @@ describe('ApiGateway', () => {
     it('replaces the method URI with a function alias ARN', () => {
       const functionAlias = 'TheFunctionAlias';
       const uriWithAwsVariables = [
-        'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${',
-        functionAlias,
-        '}/invocations'
-      ].join('');
-      const uri = { 'Fn::Sub': uriWithAwsVariables };
+        'arn:aws:apigateway:',
+        { Ref: 'AWS::Region' },
+        ':lambda:path/2015-03-31/functions/',
+        { Ref: functionAlias },
+        '/invocations'
+      ];
+      const uri = { 'Fn::Join': [ '', uriWithAwsVariables ] };
       const expected = _.set('Properties.Integration.Uri', uri, apiGatewayMethod);
       const actual = ApiGateway.replaceMethodUriWithAlias(apiGatewayMethod, functionAlias);
       expect(actual).to.deep.equal(expected);


### PR DESCRIPTION
Hi,

As our Serverless project is quite big, we use https://github.com/dougmoscrop/serverless-plugin-split-stacks to get around CloudFormation's 200 Resources per Stack limit.

Canary deployment adds quite a few resources itself, so we wouldn't be able to use it without splitting out its resources into a separate stack. Unfortunately `serverless-plugin-split-stacks` is not able to correctly pick up and rewrite references if they are written inside `Fn::Sub` function call - the end result is an invalid CF template.

The solution is to use explicit `{Ref: .... }` objects in the Resources produced by `serverless-plugin-canary-deployments` - which is precisely what this pull request is about.

Switching from `Fn::Sub` to `Fn::Join` has no real side-effects (apart from the template being a bit more ugly and verbose) and allows correct interaction with `serverless-plugin-split-stacks`. We have already tested this live.

Thanks!