### PR TITLE
Allow configurable prefix for DeploymentConfig and have a fallback to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can see a working example in the [example folder](./example/).
 
 ## <a name="configuration"></a>Configuration
 
-* `type`: (required) defines how the traffic will be shifted between Lambda function versions. It must be one of the following:
+* `type`: (required) defines how the traffic will be shifted between Lambda function versions. It must be one of the following if no custom prefix is provided:
   - `Canary10Percent5Minutes`: shifts 10 percent of traffic in the first increment. The remaining 90 percent is deployed five minutes later.
   - `Canary10Percent10Minutes`: shifts 10 percent of traffic in the first increment. The remaining 90 percent is deployed 10 minutes later.
   - `Canary10Percent15Minutes`: shifts 10 percent of traffic in the first increment. The remaining 90 percent is deployed 15 minutes later.
@@ -70,6 +70,7 @@ You can see a working example in the [example folder](./example/).
   - `Linear10PercentEvery3Minutes`: shifts 10 percent of traffic every three minutes until all traffic is shifted.
   - `Linear10PercentEvery10Minutes`: shifts 10 percent of traffic every 10 minutes until all traffic is shifted.
   - `AllAtOnce`: shifts all the traffic to the new version, useful when you only need to execute the validation hooks.
+* `prefix`: (optional) By default the prefix _CodeDeployDefault.Lambda_ is used for the type, via prefix you can configure your own prefix in order to use custom types.
 * `alias`: (required) name that will be used to create the Lambda function alias.
 * `preTrafficHook`: (optional) validation Lambda function that runs before traffic shifting. It must use the CodeDeploy SDK to notify about this step's success or failure (more info [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html)).
 * `postTrafficHook`: (optional) validation Lambda function that runs after traffic shifting. It must use the CodeDeploy SDK to notify about this step's success or failure (more info [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html))

--- a/fixtures/1.output.json
+++ b/fixtures/1.output.json
@@ -546,9 +546,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/10.output.v2-websocket.json
+++ b/fixtures/10.output.v2-websocket.json
@@ -854,9 +854,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/11.output.v2-websocket-authorizer.json
+++ b/fixtures/11.output.v2-websocket-authorizer.json
@@ -951,9 +951,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },
@@ -1010,9 +1011,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/2.output.without-hooks.json
+++ b/fixtures/2.output.without-hooks.json
@@ -413,9 +413,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/3.output.with-existing-codedeploy-role.json
+++ b/fixtures/3.output.with-existing-codedeploy-role.json
@@ -479,9 +479,10 @@
         "ServiceRoleArn": "someExistingCodeDeployRole",
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/5.output.with-trigger.json
+++ b/fixtures/5.output.with-trigger.json
@@ -560,9 +560,10 @@
         ],
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/6.output.cloudwatch-events-trigger.json
+++ b/fixtures/6.output.cloudwatch-events-trigger.json
@@ -345,9 +345,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/7.output.cloudwatch-logs-trigger.json
+++ b/fixtures/7.output.cloudwatch-logs-trigger.json
@@ -338,9 +338,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/8.output.sns-subscriptions-trigger.json
+++ b/fixtures/8.output.sns-subscriptions-trigger.json
@@ -268,9 +268,10 @@
         },
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/fixtures/9.output.iot-topic-rule.json
+++ b/fixtures/9.output.iot-topic-rule.json
@@ -763,9 +763,10 @@
         ],
         "DeploymentConfigName": {
           "Fn::Sub": [
-            "CodeDeployDefault.Lambda${ConfigName}",
+            "${ConfigNamePrefix}${ConfigName}",
             {
-              "ConfigName": "Linear10PercentEvery1Minute"
+              "ConfigName": "Linear10PercentEvery1Minute",
+              "ConfigNamePrefix": "CodeDeployDefault.Lambda"
             }
           ]
         },

--- a/lib/CfTemplateGenerators/CodeDeploy.js
+++ b/lib/CfTemplateGenerators/CodeDeploy.js
@@ -26,8 +26,8 @@ function buildFnDeploymentGroup ({ codeDeployAppName, codeDeployRoleArn, deploym
       },
       DeploymentConfigName: {
         'Fn::Sub': [
-          'CodeDeployDefault.Lambda${ConfigName}',
-          { ConfigName: deploymentSettings.type }
+          '${ConfigNamePrefix}${ConfigName}',
+          { ConfigName: deploymentSettings.type, ConfigNamePrefix: deploymentSettings.prefix || 'CodeDeployDefault.Lambda' }
         ]
       },
       DeploymentStyle: {

--- a/lib/CfTemplateGenerators/CodeDeploy.test.js
+++ b/lib/CfTemplateGenerators/CodeDeploy.test.js
@@ -40,8 +40,8 @@ describe('CodeDeploy', () => {
         },
         DeploymentConfigName: {
           'Fn::Sub': [
-            'CodeDeployDefault.Lambda${ConfigName}',
-            { ConfigName: '' }
+            '${ConfigNamePrefix}${ConfigName}',
+            { ConfigName: '', ConfigNamePrefix: 'CodeDeployDefault.Lambda' }
           ]
         },
         DeploymentStyle: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-canary-deployments",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=4.0"
   },
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "A Serverless plugin to implement canary deployment of Lambda functions",
   "main": "serverless-plugin-canary-deployments.js",
   "scripts": {


### PR DESCRIPTION
… CodeDeployDefault.Lambda to be backwards compatible.

## Proposed changes

Added an optional prefix property in deploymentSettings that can be used to override the hardcoded CodeDeployDefault.Lambda value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)