### PR TITLE
feat(api-gateway): support v1 authorizer

### DIFF
--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -33,7 +33,10 @@ functions:
       - websocket:
           route: $default
           authorizer: authorize
-      - http: GET hello
+      - http:
+          path: hello
+          method: GET
+          authorizer: authorize
       - stream:
           type: dynamodb
           arn:

--- a/lib/CfTemplateGenerators/ApiGateway.js
+++ b/lib/CfTemplateGenerators/ApiGateway.js
@@ -42,10 +42,17 @@ function replaceV2AuthorizerUriWithAlias (apiGatewayMethod, functionAlias) {
   return newMethod
 }
 
+function replaceAuthorizerUriWithAlias (apiGatewayMethod, functionAlias) {
+  const aliasUri = buildUriForAlias(functionAlias)
+  const newMethod = _.set('Properties.AuthorizerUri', aliasUri, apiGatewayMethod)
+  return newMethod
+}
+
 const ApiGateway = {
   replaceV2IntegrationUriWithAlias,
   replaceMethodUriWithAlias,
-  replaceV2AuthorizerUriWithAlias
+  replaceV2AuthorizerUriWithAlias,
+  replaceAuthorizerUriWithAlias
 }
 
 module.exports = ApiGateway


### PR DESCRIPTION
## Proposed changes

this adds support for api gateway v1 authorizers (for http eventsources). right now if you try to use an authorizer that has a canary config api gateway will throw 500 authorizer configuration exceptions.

## Types of changes

What types of changes does your code introduce to the plugin?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

tested only locally, didn't want to change the examples too much since it would mean changing the http event source to a complex type. will change if that's okay.