### PR TITLE
Update CodeDeploy default policy to AWSCodeDeployRoleForLambdaLimited

### DIFF
--- a/fixtures/1.output.json
+++ b/fixtures/1.output.json
@@ -503,7 +503,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/10.output.v2-websocket.json
+++ b/fixtures/10.output.v2-websocket.json
@@ -817,7 +817,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/11.output.v2-websocket-authorizer.json
+++ b/fixtures/11.output.v2-websocket-authorizer.json
@@ -914,7 +914,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/12.output-with-permissions-boundary.json
+++ b/fixtures/12.output-with-permissions-boundary.json
@@ -503,7 +503,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/2.output.without-hooks.json
+++ b/fixtures/2.output.without-hooks.json
@@ -370,7 +370,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/5.output.with-trigger.json
+++ b/fixtures/5.output.with-trigger.json
@@ -503,8 +503,9 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+          "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/6.output.cloudwatch-events-trigger.json
+++ b/fixtures/6.output.cloudwatch-events-trigger.json
@@ -302,7 +302,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/7.output.cloudwatch-logs-trigger.json
+++ b/fixtures/7.output.cloudwatch-logs-trigger.json
@@ -295,7 +295,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/8.output.sns-subscriptions-trigger.json
+++ b/fixtures/8.output.sns-subscriptions-trigger.json
@@ -232,7 +232,7 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
           "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/9.output.iot-topic-rule.json
+++ b/fixtures/9.output.iot-topic-rule.json
@@ -706,8 +706,9 @@
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+          "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+          "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/lib/CfTemplateGenerators/Iam.js
+++ b/lib/CfTemplateGenerators/Iam.js
@@ -3,7 +3,7 @@ function buildCodeDeployRole () {
     Type: 'AWS::IAM::Role',
     Properties: {
       ManagedPolicyArns: [
-        'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda',
+        'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
         'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
       ],
       AssumeRolePolicyDocument: {

--- a/lib/CfTemplateGenerators/Iam.js
+++ b/lib/CfTemplateGenerators/Iam.js
@@ -1,11 +1,15 @@
-function buildCodeDeployRole (codeDeployRolePermissionsBoundaryArn) {
-  const iamRoleCodeDeploy = {
+function buildCodeDeployRole (areTriggerConfigurationsSet) {
+  var managedPolicyArns = [
+    'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
+    'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+  ]
+  if (areTriggerConfigurationsSet) {
+    managedPolicyArns.push('arn:aws:iam::aws:policy/AmazonSNSFullAccess')
+  }
+  return {
     Type: 'AWS::IAM::Role',
     Properties: {
-      ManagedPolicyArns: [
-        'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-        'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
-      ],
+      ManagedPolicyArns: managedPolicyArns,
       AssumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [

--- a/lib/CfTemplateGenerators/Iam.js
+++ b/lib/CfTemplateGenerators/Iam.js
@@ -1,15 +1,15 @@
-function buildCodeDeployRole (areTriggerConfigurationsSet) {
-  var managedPolicyArns = [
+function buildCodeDeployRole (codeDeployRolePermissionsBoundaryArn, areTriggerConfigurationsSet) {
+  const attachedPolicies = [
     'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
     'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
   ]
   if (areTriggerConfigurationsSet) {
-    managedPolicyArns.push('arn:aws:iam::aws:policy/AmazonSNSFullAccess')
+    attachedPolicies.push('arn:aws:iam::aws:policy/AmazonSNSFullAccess')
   }
-  return {
+  const iamRoleCodeDeploy = {
     Type: 'AWS::IAM::Role',
     Properties: {
-      ManagedPolicyArns: managedPolicyArns,
+      ManagedPolicyArns: attachedPolicies,
       AssumeRolePolicyDocument: {
         Version: '2012-10-17',
         Statement: [

--- a/lib/CfTemplateGenerators/Iam.test.js
+++ b/lib/CfTemplateGenerators/Iam.test.js
@@ -3,28 +3,56 @@ const Iam = require('./Iam')
 
 describe('Iam', () => {
   describe('.buildCodeDeployRole', () => {
-    it('should generate a AWS::IAM::Role resource', () => {
-      const expected = {
-        Type: 'AWS::IAM::Role',
-        Properties: {
-          ManagedPolicyArns: [
-            'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-            'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
-          ],
-          AssumeRolePolicyDocument: {
-            Version: '2012-10-17',
-            Statement: [
-              {
-                Action: ['sts:AssumeRole'],
-                Effect: 'Allow',
-                Principal: { Service: ['codedeploy.amazonaws.com'] }
-              }
-            ]
+    context('when trigger configurations are not provided', () => {
+      it('should generate a CodeDeploy::Application resouce without SNS policy', () => {
+        const expected = {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            ManagedPolicyArns: [
+              'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
+              'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+            ],
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Action: ['sts:AssumeRole'],
+                  Effect: 'Allow',
+                  Principal: { Service: ['codedeploy.amazonaws.com'] }
+                }
+              ]
+            }
           }
         }
-      }
-      const actual = Iam.buildCodeDeployRole()
-      expect(actual).to.deep.equal(expected)
+        const actual = Iam.buildCodeDeployRole(false)
+        expect(actual).to.deep.equal(expected)
+      })
+    })
+    context('when trigger configurations are provided', () => {
+      it('should generate a CodeDeploy::Application resouce with SNS policy', () => {
+        const expected = {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            ManagedPolicyArns: [
+              'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
+              'arn:aws:iam::aws:policy/AWSLambdaFullAccess',
+              'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
+            ],
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Action: ['sts:AssumeRole'],
+                  Effect: 'Allow',
+                  Principal: { Service: ['codedeploy.amazonaws.com'] }
+                }
+              ]
+            }
+          }
+        }
+        const actual = Iam.buildCodeDeployRole(true)
+        expect(actual).to.deep.equal(expected)
+      })
     })
   })
   describe('.buildCodeDeployRole with IAM permissions boundary', () => {

--- a/lib/CfTemplateGenerators/Iam.test.js
+++ b/lib/CfTemplateGenerators/Iam.test.js
@@ -3,8 +3,8 @@ const Iam = require('./Iam')
 
 describe('Iam', () => {
   describe('.buildCodeDeployRole', () => {
-    context('when trigger configurations are not provided', () => {
-      it('should generate a CodeDeploy::Application resouce without SNS policy', () => {
+    context('when trigger configurations are not set', () => {
+      it('should generate a AWS::IAM::Role resource', () => {
         const expected = {
           Type: 'AWS::IAM::Role',
           Properties: {
@@ -24,12 +24,12 @@ describe('Iam', () => {
             }
           }
         }
-        const actual = Iam.buildCodeDeployRole(false)
+        const actual = Iam.buildCodeDeployRole(null, false)
         expect(actual).to.deep.equal(expected)
       })
     })
-    context('when trigger configurations are provided', () => {
-      it('should generate a CodeDeploy::Application resouce with SNS policy', () => {
+    context('when trigger configurations are set', () => {
+      it('should generate a AWS::IAM::Role resource', () => {
         const expected = {
           Type: 'AWS::IAM::Role',
           Properties: {
@@ -50,7 +50,7 @@ describe('Iam', () => {
             }
           }
         }
-        const actual = Iam.buildCodeDeployRole(true)
+        const actual = Iam.buildCodeDeployRole(null, true)
         expect(actual).to.deep.equal(expected)
       })
     })
@@ -61,7 +61,7 @@ describe('Iam', () => {
         Type: 'AWS::IAM::Role',
         Properties: {
           ManagedPolicyArns: [
-            'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda',
+            'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
             'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
           ],
           AssumeRolePolicyDocument: {

--- a/lib/CfTemplateGenerators/Iam.test.js
+++ b/lib/CfTemplateGenerators/Iam.test.js
@@ -8,7 +8,7 @@ describe('Iam', () => {
         Type: 'AWS::IAM::Role',
         Properties: {
           ManagedPolicyArns: [
-            'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda',
+            'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
             'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
           ],
           AssumeRolePolicyDocument: {

--- a/serverless-plugin-canary-deployments.js
+++ b/serverless-plugin-canary-deployments.js
@@ -40,8 +40,18 @@ class ServerlessCanaryDeployments {
   addCanaryDeploymentResources () {
     if (this.shouldDeployDeployGradually()) {
       const codeDeployApp = this.buildCodeDeployApp()
-      const codeDeployRole = this.buildCodeDeployRole()
       const functionsResources = this.buildFunctionsResources()
+      const codeDeployRole = this.buildCodeDeployRole()
+      if (codeDeployRole) {
+        // If the template has trigger configurations,
+        // attaching the SNS fully managed policy to the new role.
+        const firstKey = Object.keys(functionsResources[0])[0]
+        if (functionsResources[0][firstKey].Properties.TriggerConfigurations) {
+          codeDeployRole['CodeDeployServiceRole'].Properties.ManagedPolicyArns.push(
+            'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
+          )
+        }
+      }
       Object.assign(
         this.compiledTpl.Resources,
         codeDeployApp,

--- a/serverless-plugin-canary-deployments.js
+++ b/serverless-plugin-canary-deployments.js
@@ -52,12 +52,15 @@ class ServerlessCanaryDeployments {
   }
 
   areTriggerConfigurationsSet (functionsResources) {
-    // If the template has trigger configurations,
-    // attaching the SNS fully managed policy to the new role.
-    const firstKey = Object.keys(functionsResources[0])[0]
-    if (functionsResources[0][firstKey].Properties.TriggerConfigurations) {
-      console.log('Yup')
-      return true
+    // Checking if the template has trigger configurations.
+    for (var resource of functionsResources) {
+      for (var key of Object.keys(resource)) {
+        if (resource[key].Type === 'AWS::CodeDeploy::DeploymentGroup') {
+          if (resource[key].Properties.TriggerConfigurations) {
+            return true
+          }
+        }
+      }
     }
     return false
   }

--- a/serverless-plugin-canary-deployments.js
+++ b/serverless-plugin-canary-deployments.js
@@ -103,7 +103,7 @@ class ServerlessCanaryDeployments {
   buildCodeDeployRole (areTriggerConfigurationsSet) {
     if (this.globalSettings.codeDeployRole) return {}
     const logicalName = 'CodeDeployServiceRole'
-    const template = CfGenerators.iam.buildCodeDeployRole(this.globalSettings.codeDeployRolePermissionsBoundary)
+    const template = CfGenerators.iam.buildCodeDeployRole(this.globalSettings.codeDeployRolePermissionsBoundary, areTriggerConfigurationsSet)
     return { [logicalName]: template }
   }
 


### PR DESCRIPTION
## Proposed changes

The managed policy AWSCodeDeployRoleForLambda used for Lambda deployments has broad permissions, providing publish access to all SNS topics within the customer's accounts.
This change replaces that with a new policy AWSCodeDeployRoleForLambdaLimited which removes those permissions. 
To handle customers who may have triggers set up for SNS notifications on CodeDeploy, this change also attaches the AmazonSNSFullAccess managed policy when the deployment preferences include trigger configurations.

## Types of changes

What types of changes does your code introduce to the plugin?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

