### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0 (09.02.2021)
+- Add support for API Gateway v2 #72
+- Update CodeDeploy default policy to AWSCodeDeployRoleForLambdaLimited #98
+- Add support for IAM permissions boundaries #99
+- Patch in CodeDeploy permissions for hooks #110
+
 # 0.4.8 (28.07.2019)
 - Add support for IoT rules
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=4.0"
   },
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "A Serverless plugin to implement canary deployment of Lambda functions",
   "main": "serverless-plugin-canary-deployments.js",
   "scripts": {


### PR DESCRIPTION
- Add support for API Gateway v2 #72
- Update CodeDeploy default policy to AWSCodeDeployRoleForLambdaLimited #98
- Add support for IAM permissions boundaries #99
- Patch in CodeDeploy permissions for hooks #110