### PR TITLE
Replace deprecated AWS managed policy for codedeploy

### DIFF
--- a/fixtures/1.output.json
+++ b/fixtures/1.output.json
@@ -515,7 +515,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/10.output.v2-websocket.json
+++ b/fixtures/10.output.v2-websocket.json
@@ -829,7 +829,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/11.output.v2-websocket-authorizer.json
+++ b/fixtures/11.output.v2-websocket-authorizer.json
@@ -926,7 +926,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/12.output-with-permissions-boundary.json
+++ b/fixtures/12.output-with-permissions-boundary.json
@@ -504,7 +504,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/13.output.multiple-function-hooks.json
+++ b/fixtures/13.output.multiple-function-hooks.json
@@ -290,7 +290,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/2.output.without-hooks.json
+++ b/fixtures/2.output.without-hooks.json
@@ -371,7 +371,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/5.output.with-trigger.json
+++ b/fixtures/5.output.with-trigger.json
@@ -515,7 +515,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
           "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/fixtures/6.output.cloudwatch-events-trigger.json
+++ b/fixtures/6.output.cloudwatch-events-trigger.json
@@ -314,7 +314,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/7.output.cloudwatch-logs-trigger.json
+++ b/fixtures/7.output.cloudwatch-logs-trigger.json
@@ -307,7 +307,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/8.output.sns-subscriptions-trigger.json
+++ b/fixtures/8.output.sns-subscriptions-trigger.json
@@ -244,7 +244,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",

--- a/fixtures/9.output.iot-topic-rule.json
+++ b/fixtures/9.output.iot-topic-rule.json
@@ -718,7 +718,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
-          "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+          "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
           "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
         ],
         "AssumeRolePolicyDocument": {

--- a/lib/CfTemplateGenerators/Iam.js
+++ b/lib/CfTemplateGenerators/Iam.js
@@ -3,7 +3,7 @@ const _ = require('lodash/fp')
 function buildCodeDeployRole (codeDeployRolePermissionsBoundaryArn, areTriggerConfigurationsSet) {
   const attachedPolicies = [
     'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-    'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+    'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
   ]
   if (areTriggerConfigurationsSet) {
     attachedPolicies.push('arn:aws:iam::aws:policy/AmazonSNSFullAccess')

--- a/lib/CfTemplateGenerators/Iam.test.js
+++ b/lib/CfTemplateGenerators/Iam.test.js
@@ -10,7 +10,7 @@ describe('Iam', () => {
           Properties: {
             ManagedPolicyArns: [
               'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-              'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+              'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
             ],
             AssumeRolePolicyDocument: {
               Version: '2012-10-17',
@@ -35,7 +35,7 @@ describe('Iam', () => {
           Properties: {
             ManagedPolicyArns: [
               'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-              'arn:aws:iam::aws:policy/AWSLambdaFullAccess',
+              'arn:aws:iam::aws:policy/AWSLambda_FullAccess',
               'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
             ],
             AssumeRolePolicyDocument: {
@@ -62,7 +62,7 @@ describe('Iam', () => {
         Properties: {
           ManagedPolicyArns: [
             'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-            'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+            'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
           ],
           AssumeRolePolicyDocument: {
             Version: '2012-10-17',
@@ -201,7 +201,7 @@ describe('Iam', () => {
           Properties: {
             ManagedPolicyArns: [
               'arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited',
-              'arn:aws:iam::aws:policy/AWSLambdaFullAccess'
+              'arn:aws:iam::aws:policy/AWSLambda_FullAccess'
             ],
             AssumeRolePolicyDocument: {
               Version: '2012-10-17',


### PR DESCRIPTION
After March 1, 2021, the AWS managed policies AWSLambdaReadOnlyAccess and AWSLambdaFullAccess will be deprecated and can no longer be attached to new IAM users.

AWS Lambda has introduced a new AWS managed policy.

The AWSLambda_FullAccess policy grants full access to Lambda, Lambda console features, and other related AWS services. This policy was created by scoping down the previous policy AWSLambdaFullAccess.

fixes #115

## Proposed changes

See issue https://github.com/davidgf/serverless-plugin-canary-deployments/issues/115

## Types of changes

What types of changes does your code introduce to the plugin?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
