### PR TITLE
feat: allow lambda ARN to be used for deployment hooks

### DIFF
--- a/fixtures/16.input.lambda-preTrafficHook-arn.json
+++ b/fixtures/16.input.lambda-preTrafficHook-arn.json
@@ -1,0 +1,488 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "The AWS CloudFormation template for this Serverless application",
+    "Resources": {
+      "ServerlessDeploymentBucket": {
+        "Type": "AWS::S3::Bucket"
+      },
+      "HelloLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-hello"
+        }
+      },
+      "PreHookLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-preHook"
+        }
+      },
+      "PostHookLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-postHook"
+        }
+      },
+      "IamRoleLambdaExecution": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": ["lambda.amazonaws.com"]
+                },
+                "Action": ["sts:AssumeRole"]
+              }
+            ]
+          },
+          "Policies": [
+            {
+              "PolicyName": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    "dev",
+                    "canary-deployments-test",
+                    "lambda"
+                  ]
+                ]
+              },
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": ["logs:CreateLogStream"],
+                    "Resource": [
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-hello:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-preHook:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-postHook:*"
+                      }
+                    ]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["logs:PutLogEvents"],
+                    "Resource": [
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-hello:*:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-preHook:*:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-postHook:*:*"
+                      }
+                    ]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["codedeploy:*"],
+                    "Resource": ["*"]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                      "dynamodb:DescribeStream",
+                      "dynamodb:ListStreams"
+                    ],
+                    "Resource": [
+                      {
+                        "Fn::GetAtt": ["StreamsTestTable", "StreamArn"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "Path": "/",
+          "RoleName": {
+            "Fn::Join": [
+              "-",
+              [
+                "canary-deployments-test",
+                "dev",
+                "us-east-1",
+                "lambdaRole"
+              ]
+            ]
+          }
+        }
+      },
+      "HelloLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-hello",
+          "Handler": "handler.hello",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["HelloLogGroup", "IamRoleLambdaExecution"]
+      },
+      "HelloLambdaVersionFYAirphUvjV7H12yGxU1eQrqAiSBMjAi9hdLPgV62L8": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "HelloLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "PreHookLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-preHook",
+          "Handler": "hooks.pre",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["PreHookLogGroup", "IamRoleLambdaExecution"]
+      },
+      "PreHookLambdaVersionIYyrXlfQM5jjU68REvnAzRxhgq9eoLqSsDjy0": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "PreHookLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "PostHookLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-postHook",
+          "Handler": "hooks.post",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["PostHookLogGroup", "IamRoleLambdaExecution"]
+      },
+      "PostHookLambdaVersiondh0VUUAh9BrmvORqx3vDEIcHxolKWKCO1YL45mVTbg": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "PostHookLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "ApiGatewayRestApi": {
+        "Type": "AWS::ApiGateway::RestApi",
+        "Properties": {
+          "Name": "dev-canary-deployments-test",
+          "EndpointConfiguration": {
+            "Types": ["EDGE"]
+          }
+        }
+      },
+      "ApiGatewayResourceHello": {
+        "Type": "AWS::ApiGateway::Resource",
+        "Properties": {
+          "ParentId": {
+            "Fn::GetAtt": ["ApiGatewayRestApi", "RootResourceId"]
+          },
+          "PathPart": "hello",
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          }
+        }
+      },
+      "ApiGatewayMethodHelloGet": {
+        "Type": "AWS::ApiGateway::Method",
+        "Properties": {
+          "HttpMethod": "GET",
+          "RequestParameters": {},
+          "ResourceId": {
+            "Ref": "ApiGatewayResourceHello"
+          },
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          },
+          "ApiKeyRequired": false,
+          "AuthorizationType": "NONE",
+          "Integration": {
+            "IntegrationHttpMethod": "POST",
+            "Type": "AWS_PROXY",
+            "Uri": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:apigateway:",
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  ":lambda:path/2015-03-31/functions/",
+                  {
+                    "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+                  },
+                  "/invocations"
+                ]
+              ]
+            }
+          },
+          "MethodResponses": []
+        }
+      },
+      "ApiGatewayDeployment12345": {
+        "Type": "AWS::ApiGateway::Deployment",
+        "Properties": {
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          },
+          "StageName": "dev"
+        },
+        "DependsOn": ["ApiGatewayMethodHelloGet"]
+      },
+      "HelloLambdaPermissionApiGateway": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "apigateway.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId"
+                },
+                ":",
+                {
+                  "Ref": "ApiGatewayRestApi"
+                },
+                "/*/*"
+              ]
+            ]
+          }
+        }
+      },
+      "SNSTopicSnsTopic": {
+        "Type": "AWS::SNS::Topic",
+        "Properties": {
+          "TopicName": "snsTopic",
+          "DisplayName": "",
+          "Subscription": [
+            {
+              "Endpoint": {
+                "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+              },
+              "Protocol": "lambda"
+            }
+          ]
+        }
+      },
+      "HelloLambdaPermissionSnsTopicSNS": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "sns.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId"
+                },
+                ":",
+                "snsTopic"
+              ]
+            ]
+          }
+        }
+      },
+      "S3BucketS3SampleBucket": {
+        "Type": "AWS::S3::Bucket",
+        "Properties": {
+          "BucketName": "s3SampleBucket",
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Event": "s3:ObjectCreated:*",
+                "Function": {
+                  "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+                }
+              }
+            ]
+          }
+        },
+        "DependsOn": ["HelloLambdaPermissionS3SampleBucketS3"]
+      },
+      "HelloLambdaPermissionS3SampleBucketS3": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "s3.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": ["", ["arn:aws:s3:::s3SampleBucket"]]
+          }
+        }
+      },
+      "HelloEventSourceMappingDynamodbStreamsTestTable": {
+        "Type": "AWS::Lambda::EventSourceMapping",
+        "DependsOn": "IamRoleLambdaExecution",
+        "Properties": {
+          "BatchSize": 10,
+          "EventSourceArn": {
+            "Fn::GetAtt": ["StreamsTestTable", "StreamArn"]
+          },
+          "FunctionName": {
+            "Fn::GetAtt": ["HelloLambdaFunction", "Arn"]
+          },
+          "StartingPosition": "TRIM_HORIZON",
+          "Enabled": "True"
+        }
+      },
+      "HelloFooAlarm": {
+        "Type": "AWS::CloudWatch::Alarm",
+        "Properties": {
+          "Namespace": "AWS/Lambda",
+          "MetricName": "Errors",
+          "Threshold": 1,
+          "Period": 60,
+          "EvaluationPeriods": 1,
+          "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+          "OKActions": [],
+          "AlarmActions": [],
+          "InsufficientDataActions": [],
+          "Dimensions": [
+            {
+              "Name": "FunctionName",
+              "Value": {
+                "Ref": "HelloLambdaFunction"
+              }
+            }
+          ],
+          "TreatMissingData": "missing",
+          "Statistic": "Minimum"
+        }
+      },
+      "StreamsTestTable": {
+        "Type": "AWS::DynamoDB::Table",
+        "Properties": {
+          "TableName": "StreamsTestTable",
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "ReadCapacityUnits": 1,
+            "WriteCapacityUnits": 1
+          },
+          "StreamSpecification": {
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          }
+        }
+      }
+    },
+    "Outputs": {
+      "ServerlessDeploymentBucketName": {
+        "Value": {
+          "Ref": "ServerlessDeploymentBucket"
+        }
+      },
+      "HelloLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "HelloLambdaVersionFYAirphUvjV7H12yGxU1eQrqAiSBMjAi9hdLPgV62L8"
+        }
+      },
+      "PreHookLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "PreHookLambdaVersionIYyrXlfQM5jjU68REvnAzRxhgq9eoLqSsDjy0"
+        }
+      },
+      "PostHookLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "PostHookLambdaVersiondh0VUUAh9BrmvORqx3vDEIcHxolKWKCO1YL45mVTbg"
+        }
+      },
+      "ServiceEndpoint": {
+        "Description": "URL of the service endpoint",
+        "Value": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              ".execute-api.us-east-1.amazonaws.com/dev"
+            ]
+          ]
+        }
+      }
+    }
+  }
+  

--- a/fixtures/16.output.lambda-preTrafficHook-arn.json
+++ b/fixtures/16.output.lambda-preTrafficHook-arn.json
@@ -1,0 +1,597 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "The AWS CloudFormation template for this Serverless application",
+    "Resources": {
+      "ServerlessDeploymentBucket": {
+        "Type": "AWS::S3::Bucket"
+      },
+      "HelloLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-hello"
+        }
+      },
+      "PreHookLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-preHook"
+        }
+      },
+      "PostHookLogGroup": {
+        "Type": "AWS::Logs::LogGroup",
+        "Properties": {
+          "LogGroupName": "/aws/lambda/canary-deployments-test-dev-postHook"
+        }
+      },
+      "IamRoleLambdaExecution": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": ["lambda.amazonaws.com"]
+                },
+                "Action": ["sts:AssumeRole"]
+              }
+            ]
+          },
+          "Policies": [
+            {
+              "PolicyName": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    "dev",
+                    "canary-deployments-test",
+                    "lambda"
+                  ]
+                ]
+              },
+              "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": ["logs:CreateLogStream"],
+                    "Resource": [
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-hello:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-preHook:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-postHook:*"
+                      }
+                    ]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["logs:PutLogEvents"],
+                    "Resource": [
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-hello:*:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-preHook:*:*"
+                      },
+                      {
+                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/canary-deployments-test-dev-postHook:*:*"
+                      }
+                    ]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["codedeploy:*"],
+                    "Resource": ["*"]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": [
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                      "dynamodb:DescribeStream",
+                      "dynamodb:ListStreams"
+                    ],
+                    "Resource": [
+                      {
+                        "Fn::GetAtt": ["StreamsTestTable", "StreamArn"]
+                      }
+                    ]
+                  },
+                  {
+                    "Action": ["codedeploy:PutLifecycleEventHookExecutionStatus"],
+                    "Effect": "Allow",
+                    "Resource": [
+                      {
+                        "Fn::Sub": "arn:${AWS::Partition}:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup:${CanarydeploymentstestdevDeploymentApplication}/canary-deployments-test-dev-HelloLambdaFunctionDeploymentGroup"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "Path": "/",
+          "RoleName": {
+            "Fn::Join": [
+              "-",
+              [
+                "canary-deployments-test",
+                "dev",
+                "us-east-1",
+                "lambdaRole"
+              ]
+            ]
+          }
+        }
+      },
+      "HelloLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-hello",
+          "Handler": "handler.hello",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["HelloLogGroup", "IamRoleLambdaExecution"]
+      },
+      "HelloLambdaVersionFYAirphUvjV7H12yGxU1eQrqAiSBMjAi9hdLPgV62L8": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "HelloLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "PreHookLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-preHook",
+          "Handler": "hooks.pre",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["PreHookLogGroup", "IamRoleLambdaExecution"]
+      },
+      "PreHookLambdaVersionIYyrXlfQM5jjU68REvnAzRxhgq9eoLqSsDjy0": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "PreHookLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "PostHookLambdaFunction": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": {
+              "Ref": "ServerlessDeploymentBucket"
+            },
+            "S3Key": "serverless/canary-deployments-test/dev/1520191533287-2018-03-04T19:25:33.287Z/canary-deployments-test.zip"
+          },
+          "FunctionName": "canary-deployments-test-dev-postHook",
+          "Handler": "hooks.post",
+          "MemorySize": 1024,
+          "Role": {
+            "Fn::GetAtt": ["IamRoleLambdaExecution", "Arn"]
+          },
+          "Runtime": "nodejs6.10",
+          "Timeout": 6
+        },
+        "DependsOn": ["PostHookLogGroup", "IamRoleLambdaExecution"]
+      },
+      "PostHookLambdaVersiondh0VUUAh9BrmvORqx3vDEIcHxolKWKCO1YL45mVTbg": {
+        "Type": "AWS::Lambda::Version",
+        "DeletionPolicy": "Retain",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "PostHookLambdaFunction"
+          },
+          "CodeSha256": "sZvdDgxnAbKe1yaQga0XJPD82+o5jFWz+J3lR+q9UHU="
+        }
+      },
+      "ApiGatewayRestApi": {
+        "Type": "AWS::ApiGateway::RestApi",
+        "Properties": {
+          "Name": "dev-canary-deployments-test",
+          "EndpointConfiguration": {
+            "Types": ["EDGE"]
+          }
+        }
+      },
+      "ApiGatewayResourceHello": {
+        "Type": "AWS::ApiGateway::Resource",
+        "Properties": {
+          "ParentId": {
+            "Fn::GetAtt": ["ApiGatewayRestApi", "RootResourceId"]
+          },
+          "PathPart": "hello",
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          }
+        }
+      },
+      "ApiGatewayMethodHelloGet": {
+        "Type": "AWS::ApiGateway::Method",
+        "Properties": {
+          "HttpMethod": "GET",
+          "RequestParameters": {},
+          "ResourceId": {
+            "Ref": "ApiGatewayResourceHello"
+          },
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          },
+          "ApiKeyRequired": false,
+          "AuthorizationType": "NONE",
+          "Integration": {
+            "IntegrationHttpMethod": "POST",
+            "Type": "AWS_PROXY",
+            "Uri": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:apigateway:",
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  ":lambda:path/2015-03-31/functions/",
+                  {
+                    "Ref": "HelloLambdaFunctionAliasLive"
+                  },
+                  "/invocations"
+                ]
+              ]
+            }
+          },
+          "MethodResponses": []
+        }
+      },
+      "ApiGatewayDeployment12345": {
+        "Type": "AWS::ApiGateway::Deployment",
+        "Properties": {
+          "RestApiId": {
+            "Ref": "ApiGatewayRestApi"
+          },
+          "StageName": "dev"
+        },
+        "DependsOn": ["ApiGatewayMethodHelloGet"]
+      },
+      "HelloLambdaPermissionApiGateway": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "HelloLambdaFunctionAliasLive"
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "apigateway.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId"
+                },
+                ":",
+                {
+                  "Ref": "ApiGatewayRestApi"
+                },
+                "/*/*"
+              ]
+            ]
+          }
+        }
+      },
+      "SNSTopicSnsTopic": {
+        "Type": "AWS::SNS::Topic",
+        "Properties": {
+          "TopicName": "snsTopic",
+          "DisplayName": "",
+          "Subscription": [
+            {
+              "Endpoint": {
+                "Ref": "HelloLambdaFunctionAliasLive"
+              },
+              "Protocol": "lambda"
+            }
+          ]
+        }
+      },
+      "HelloLambdaPermissionSnsTopicSNS": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "HelloLambdaFunctionAliasLive"
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "sns.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId"
+                },
+                ":",
+                "snsTopic"
+              ]
+            ]
+          }
+        }
+      },
+      "S3BucketS3SampleBucket": {
+        "Type": "AWS::S3::Bucket",
+        "Properties": {
+          "BucketName": "s3SampleBucket",
+          "NotificationConfiguration": {
+            "LambdaConfigurations": [
+              {
+                "Event": "s3:ObjectCreated:*",
+                "Function": {
+                  "Ref": "HelloLambdaFunctionAliasLive"
+                }
+              }
+            ]
+          }
+        },
+        "DependsOn": ["HelloLambdaPermissionS3SampleBucketS3"]
+      },
+      "HelloLambdaPermissionS3SampleBucketS3": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+          "FunctionName": {
+            "Ref": "HelloLambdaFunctionAliasLive"
+          },
+          "Action": "lambda:InvokeFunction",
+          "Principal": "s3.amazonaws.com",
+          "SourceArn": {
+            "Fn::Join": ["", ["arn:aws:s3:::s3SampleBucket"]]
+          }
+        }
+      },
+      "HelloEventSourceMappingDynamodbStreamsTestTable": {
+        "Type": "AWS::Lambda::EventSourceMapping",
+        "DependsOn": "IamRoleLambdaExecution",
+        "Properties": {
+          "BatchSize": 10,
+          "EventSourceArn": {
+            "Fn::GetAtt": ["StreamsTestTable", "StreamArn"]
+          },
+          "FunctionName": {
+            "Ref": "HelloLambdaFunctionAliasLive"
+          },
+          "StartingPosition": "TRIM_HORIZON",
+          "Enabled": "True"
+        }
+      },
+      "HelloFooAlarm": {
+        "Type": "AWS::CloudWatch::Alarm",
+        "Properties": {
+          "Namespace": "AWS/Lambda",
+          "MetricName": "Errors",
+          "Threshold": 1,
+          "Period": 60,
+          "EvaluationPeriods": 1,
+          "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+          "OKActions": [],
+          "AlarmActions": [],
+          "InsufficientDataActions": [],
+          "Dimensions": [
+            {
+              "Name": "FunctionName",
+              "Value": {
+                "Ref": "HelloLambdaFunction"
+              }
+            }
+          ],
+          "TreatMissingData": "missing",
+          "Statistic": "Minimum"
+        }
+      },
+      "StreamsTestTable": {
+        "Type": "AWS::DynamoDB::Table",
+        "Properties": {
+          "TableName": "StreamsTestTable",
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "ReadCapacityUnits": 1,
+            "WriteCapacityUnits": 1
+          },
+          "StreamSpecification": {
+            "StreamViewType": "NEW_AND_OLD_IMAGES"
+          }
+        }
+      },
+      "CanarydeploymentstestdevDeploymentApplication": {
+        "Type": "AWS::CodeDeploy::Application",
+        "Properties": {
+          "ComputePlatform": "Lambda"
+        }
+      },
+      "CodeDeployServiceRole": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+          "ManagedPolicyArns": [
+            "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambdaLimited",
+            "arn:aws:iam::aws:policy/AWSLambda_FullAccess"
+          ],
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Action": ["sts:AssumeRole"],
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": ["codedeploy.amazonaws.com"]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "HelloLambdaFunctionDeploymentGroup": {
+        "Type": "AWS::CodeDeploy::DeploymentGroup",
+        "Properties": {
+          "ApplicationName": {
+            "Ref": "CanarydeploymentstestdevDeploymentApplication"
+          },
+          "AutoRollbackConfiguration": {
+            "Enabled": true,
+            "Events": [
+              "DEPLOYMENT_FAILURE",
+              "DEPLOYMENT_STOP_ON_ALARM",
+              "DEPLOYMENT_STOP_ON_REQUEST"
+            ]
+          },
+          "ServiceRoleArn": {
+            "Fn::GetAtt": ["CodeDeployServiceRole", "Arn"]
+          },
+          "DeploymentConfigName": {
+            "Fn::Sub": [
+              "CodeDeployDefault.Lambda${ConfigName}",
+              {
+                "ConfigName": "Linear10PercentEvery1Minute"
+              }
+            ]
+          },
+          "DeploymentGroupName": "canary-deployments-test-dev-HelloLambdaFunctionDeploymentGroup",
+          "DeploymentStyle": {
+            "DeploymentType": "BLUE_GREEN",
+            "DeploymentOption": "WITH_TRAFFIC_CONTROL"
+          },
+          "AlarmConfiguration": {
+            "Alarms": [
+              {
+                "Name": {
+                  "Ref": "HelloFooAlarm"
+                }
+              }
+            ],
+            "Enabled": true
+          }
+        }
+      },
+      "HelloLambdaFunctionAliasLive": {
+        "Type": "AWS::Lambda::Alias",
+        "Properties": {
+          "FunctionVersion": {
+            "Fn::GetAtt": [
+              "HelloLambdaVersionFYAirphUvjV7H12yGxU1eQrqAiSBMjAi9hdLPgV62L8",
+              "Version"
+            ]
+          },
+          "FunctionName": {
+            "Ref": "HelloLambdaFunction"
+          },
+          "Name": "Live"
+        },
+        "UpdatePolicy": {
+          "CodeDeployLambdaAliasUpdate": {
+            "ApplicationName": {
+              "Ref": "CanarydeploymentstestdevDeploymentApplication"
+            },
+            "AfterAllowTrafficHook": {
+              "Fn::Sub": "arn:aws:lambda:ap-southeast-2:000000000000:function:serverless-prehook"
+            },
+            "BeforeAllowTrafficHook": {
+              "Fn::Sub": "arn:aws:lambda:ap-southeast-2:000000000000:function:serverless-prehook"
+            },
+            "DeploymentGroupName": {
+              "Ref": "HelloLambdaFunctionDeploymentGroup"
+            }
+          }
+        }
+      }
+    },
+    "Outputs": {
+      "ServerlessDeploymentBucketName": {
+        "Value": {
+          "Ref": "ServerlessDeploymentBucket"
+        }
+      },
+      "HelloLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "HelloLambdaVersionFYAirphUvjV7H12yGxU1eQrqAiSBMjAi9hdLPgV62L8"
+        }
+      },
+      "PreHookLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "PreHookLambdaVersionIYyrXlfQM5jjU68REvnAzRxhgq9eoLqSsDjy0"
+        }
+      },
+      "PostHookLambdaFunctionQualifiedArn": {
+        "Description": "Current Lambda function version",
+        "Value": {
+          "Ref": "PostHookLambdaVersiondh0VUUAh9BrmvORqx3vDEIcHxolKWKCO1YL45mVTbg"
+        }
+      },
+      "ServiceEndpoint": {
+        "Description": "URL of the service endpoint",
+        "Value": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              ".execute-api.us-east-1.amazonaws.com/dev"
+            ]
+          ]
+        }
+      }
+    }
+  }
+  

--- a/fixtures/16.service.lambda-preTrafficHook-arn.json
+++ b/fixtures/16.service.lambda-preTrafficHook-arn.json
@@ -1,0 +1,46 @@
+{
+    "service": "canary-deployments-test",
+    "custom": {
+      "deploymentSettings": {
+        "stages": ["dev"]
+      }
+    },
+    "functions": {
+      "hello": {
+        "handler": "handler.hello",
+        "events": [
+          {
+            "http": "GET hello"
+          },
+          {
+            "stream": {
+              "type": "dynamodb",
+              "arn": {
+                "Fn::GetAtt": ["StreamsTestTable", "StreamArn"]
+              }
+            }
+          },
+          {
+            "sns": "snsTopic"
+          },
+          {
+            "s3": "s3SampleBucket"
+          }
+        ],
+        "deploymentSettings": {
+          "type": "Linear10PercentEvery1Minute",
+          "alias": "Live",
+          "preTrafficHook": "arn:aws:lambda:ap-southeast-2:000000000000:function:serverless-prehook",
+          "postTrafficHook": "arn:aws:lambda:ap-southeast-2:000000000000:function:serverless-prehook",
+          "alarms": ["HelloFooAlarm"]
+        }
+      },
+      "preHook": {
+        "handler": "hooks.pre"
+      },
+      "postHook": {
+        "handler": "hooks.post"
+      }
+    }
+  }
+  

--- a/lib/CfTemplateGenerators/Lambda.js
+++ b/lib/CfTemplateGenerators/Lambda.js
@@ -5,8 +5,8 @@ function buildUpdatePolicy ({ codeDeployApp, deploymentGroup, afterHook, beforeH
   const updatePolicy = {
     CodeDeployLambdaAliasUpdate: {
       ApplicationName: { Ref: codeDeployApp },
-      AfterAllowTrafficHook: { Ref: afterHook },
-      BeforeAllowTrafficHook: { Ref: beforeHook },
+      AfterAllowTrafficHook: afterHook,
+      BeforeAllowTrafficHook: beforeHook,
       DeploymentGroupName: { Ref: deploymentGroup }
     }
   }

--- a/lib/CfTemplateGenerators/Lambda.test.js
+++ b/lib/CfTemplateGenerators/Lambda.test.js
@@ -27,15 +27,15 @@ describe('Lambda', () => {
         const trafficShiftingSettings = {
           codeDeployApp: 'CodeDeployAppName',
           deploymentGroup: 'DeploymentGroup',
-          beforeHook: 'BeforeHookLambdaFn',
-          afterHook: 'AfterHookLambdaFn'
+          beforeHook: { Ref: 'BeforeHookLambdaFn' },
+          afterHook: { Ref: 'AfterHookLambdaFn' }
         }
         const expected = {
           UpdatePolicy: {
             CodeDeployLambdaAliasUpdate: {
               ApplicationName: { Ref: trafficShiftingSettings.codeDeployApp },
-              AfterAllowTrafficHook: { Ref: trafficShiftingSettings.afterHook },
-              BeforeAllowTrafficHook: { Ref: trafficShiftingSettings.beforeHook },
+              AfterAllowTrafficHook: trafficShiftingSettings.afterHook,
+              BeforeAllowTrafficHook: trafficShiftingSettings.beforeHook,
               DeploymentGroupName: { Ref: trafficShiftingSettings.deploymentGroup }
             }
           }

--- a/serverless-plugin-canary-deployments.js
+++ b/serverless-plugin-canary-deployments.js
@@ -168,8 +168,8 @@ class ServerlessCanaryDeployments {
     const { alias } = deploymentSettings
     const functionVersion = this.getVersionNameFor(functionName)
     const logicalName = `${functionName}Alias${alias}`
-    const beforeHook = this.getFunctionName(deploymentSettings.preTrafficHook)
-    const afterHook = this.getFunctionName(deploymentSettings.postTrafficHook)
+    const beforeHook = this.getDeploymentHook(deploymentSettings.preTrafficHook)
+    const afterHook = this.getDeploymentHook(deploymentSettings.postTrafficHook)
     const trafficShiftingSettings = {
       codeDeployApp: this.codeDeployAppName,
       deploymentGroup,
@@ -195,6 +195,17 @@ class ServerlessCanaryDeployments {
 
   getFunctionName (slsFunctionName) {
     return slsFunctionName ? this.naming.getLambdaLogicalId(slsFunctionName) : null
+  }
+
+  getDeploymentHook (slsFunctionName) {
+    if (!slsFunctionName) {
+      return null
+    }
+
+    const isLambdaARN = slsFunctionName.includes('arn:aws:lambda')
+    return isLambdaARN
+      ? { 'Fn::Sub': slsFunctionName }
+      : { Ref: this.naming.getLambdaLogicalId(slsFunctionName) }
   }
 
   buildPermissionsForAlias ({ functionName, functionAlias }) {


### PR DESCRIPTION
## Proposed changes

Currently you cannot specify an ARN for the deployment hooks `preTrafficHook` and `postTrafficHook`. The deployment hooks only expect a resource name that should exist within the cloudformation stack. 

This change will allow us to have a single global lambda that will be invoked by code deploy instead of needing a lambda per cloudformation stack.

## Types of changes

What types of changes does your code introduce to the plugin?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I opted for a relatively simple check on whether the given input is an ARN. Happy to introduce something like `@aws-sdk/util-arn-parser` instead if that's preferable.
